### PR TITLE
Replace RuAutoPunct with BERT-based punctuation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ data/
 | 01 | **Audio extraction** | `ffmpeg` | `01_extract.wav` |
 | 02 | **Voice activity detection** | *Silero VAD* (`silero-vad`) | `02_vad.json` |
 | 03 | **ASR** | *Whisper‑large‑v3‑turbo* via **faster‑whisper** (`int8_float16`) | `03_asr.jsonl` |
-| 04 | **Punctuation & casing** | `ruautopunct` | `04_punct.jsonl` |
+| 04 | **Punctuation & casing** | `deepmultilingualpunctuation` | `04_punct.jsonl` |
 | 05 | **Paragraph grouping** | custom merge ≤ 250 chars **or** ≤ 15 s | `05_parsed.jsonl` |
 | 06 | **Machine translation** | *ALMA‑13B‑R* via **CTranslate2** (`int8_float16`) + optional TSV glossary | `06_ru.jsonl` |
 | 07 | **Text‑to‑speech** | *Coqui XTTS‑v2* (Russian female) | `07_tts.wav` |
@@ -94,7 +94,7 @@ dependencies:
       - ctranslate2==4.6.0
       - sentencepiece
       - silero-vad==0.4.0
-      - ruautopunct==1.2.3
+      - deepmultilingualpunctuation==1.0.1
       - tts==0.22.0           # Coqui XTTS‑v2
       - torch                 # auto‑selects correct CUDA wheel
 ```
@@ -139,7 +139,7 @@ BATCH_MT  = 16
 
 * **VAD**: `silero.utils.get_speech_ts(wav, model, sampling_rate, min_speech_duration_ms=300, max_speech_duration_s=30)`.  
 * **ASR**: `WhisperModel.transcribe(..., word_timestamps=True, vad_filter=False)`.  
-* **ruautopunct**: use `RuAutoPunct().restore_punctuations_batch(...)`.  
+* **Punctuation**: `deepmultilingualpunctuation.PunctuationModel.restore_punctuation(text)`.
 * **ALMA via CTranslate2**: pass target prefix `[">>ru<<"]`; enable `beam_size=4`, `max_batch_size` from config.  
 * **XTTS‑v2** example:
 

--- a/env.yml
+++ b/env.yml
@@ -13,6 +13,6 @@ dependencies:
       - ctranslate2==4.6.0
       - sentencepiece
       - silero-vad==0.4.0
-      - ruautopunct==1.2.3
+      - deepmultilingualpunctuation==1.0.1
       - tts==0.22.0
       - torch

--- a/src/stages/stage04_punct.py
+++ b/src/stages/stage04_punct.py
@@ -1,7 +1,16 @@
 import logging
 from pathlib import Path
-from ruautopunct import RuAutoPunct
+from deepmultilingualpunctuation import PunctuationModel
 from src.utils.io import read_jsonl, write_jsonl
+
+_MODEL = None
+
+
+def _get_model():
+    global _MODEL
+    if _MODEL is None:
+        _MODEL = PunctuationModel()
+    return _MODEL
 
 
 def run(asr_jsonl: Path, punct_out: Path):
@@ -10,8 +19,7 @@ def run(asr_jsonl: Path, punct_out: Path):
         return
     logging.info(f"[04] Restoring punctuation for {asr_jsonl}")
     segments = read_jsonl(asr_jsonl)
-    texts = [seg['text'] for seg in segments]
-    punct = RuAutoPunct().restore_punctuations_batch(texts)
-    for seg, p in zip(segments, punct):
-        seg['text'] = p
+    model = _get_model()
+    for seg in segments:
+        seg['text'] = model.restore_punctuation(seg['text'])
     write_jsonl(segments, punct_out)


### PR DESCRIPTION
## Summary
- switch Stage 04 to use `deepmultilingualpunctuation` instead of RuAutoPunct
- update environment and agent documentation

## Testing
- `python main.py --save-interm` *(fails: No module named 'ffmpeg')*

------
https://chatgpt.com/codex/tasks/task_e_685034358fec8325ab66c8f41517896b